### PR TITLE
Reduce provisioned capacity to within free tier

### DIFF
--- a/CloudFormation/CreateZombieWorkshop.json
+++ b/CloudFormation/CreateZombieWorkshop.json
@@ -172,8 +172,8 @@
           {"AttributeName": "timestamp", "KeyType": "RANGE"}
         ],
         "ProvisionedThroughput": {
-          "ReadCapacityUnits": 25,
-          "WriteCapacityUnits": 25
+          "ReadCapacityUnits": 10,
+          "WriteCapacityUnits": 10
         }
       }
     },
@@ -197,8 +197,8 @@
           {"AttributeName": "talktime", "KeyType": "RANGE"}
         ],
         "ProvisionedThroughput": {
-          "ReadCapacityUnits": 50,
-          "WriteCapacityUnits": 50
+          "ReadCapacityUnits": 10,
+          "WriteCapacityUnits": 10
         }
       }
     },


### PR DESCRIPTION
Although the lab should be torn down afterwards, I feel 10 read/write capacity units (plus bursts) each should be more than enough for the entire lab.