### PR TITLE
Suggest using existing role instead of creating new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ In this section, you’ll create a free-trial Twilio SMS phone number. You will 
 
 *   The functions in this workshop are authored in Nodejs 0.10 but will work regardless of the version of Node you choose when creating your Function in the console. The workshop will soon be upgraded to use Nodejs 4.3.
 
-14\. After you have copied the code into the Lambda inline code console and modifed the POST URL, scroll down to the **Lambda function handler and role** section. For the role, select **Basic execution role** from the dropdown and click "Allow" on the popup window to confirm the creation of the role. For this Lambda function we do not need any IAM permissions to other AWS services.
+14\. After you have copied the code into the Lambda inline code console and modifed the POST URL, scroll down to the **Lambda function handler and role** section. For the role, select **Choose an existing role** from the dropdown and select the existing roles in the **Existing role** dropdown. For this Lambda function we do not need any IAM permissions to other AWS services.
 
 15\. Keep all the rest of the defaults set and click **Next** and then **Create function** on the Review page to create your Lambda function.
 


### PR DESCRIPTION
The guide is outdated in relation to the UI and it's quicker and easier just to select the preconfigured role