### PR TITLE
Puts the challenge before the cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,12 @@ When you've copied the code into the Lambda browser editor, locate the variable 
 
 * This Lambda Function takes the zombie sensor message from SNS, parses it, and makes an AWS SigV4 signed HTTPS POST request to your API Gateway message endpoint. That endpoint inserts the record into DynamoDB as a message making it available to the application on subsequent poll requests.
 
+* * *
+
+## Appendix
+
+* Channel Challenge: Currently all messages sent in the survivor app are saved in the database with a channel of 'default' - all survivors can see these messages. Your challenge is to modify the application so that users have the option to scope their messages to only display to survivors in the same "Camp" (Camp is an attribute that is collected from users when they sign up for a user account). You will need to modify the JS application as well as the backend messages database and Lambda functions to work with this "Camp" attribute instead of the existing 'channel' attribute.
+
 ## Workshop Cleanup
 
 1\. To cleanup your environment, it is recommended to first delete these manual resources you created in the labs before deleting your CloudFormation stack, as there may be resource dependencies that stop the Stack from deleting. Follow steps 2-6 before deleting your Stack.
@@ -735,8 +741,4 @@ When you've copied the code into the Lambda browser editor, locate the variable 
 
 * When the stack has been successfully deleted, it should no longer display in the list of Active stacks. If you run into any issues deleting stacks, please notify a workshop instructor or contact [AWS Support](https://console.aws.amazon.com/support/home) for additional assistance.
 
-* * *
 
-## Appendix
-
-* Channel Challenge: Currently all messages sent in the survivor app are saved in the database with a channel of 'default' - all survivors can see these messages. Your challenge is to modify the application so that users have the option to scope their messages to only display to survivors in the same "Camp" (Camp is an attribute that is collected from users when they sign up for a user account). You will need to modify the JS application as well as the backend messages database and Lambda functions to work with this "Camp" attribute instead of the existing 'channel' attribute.


### PR DESCRIPTION
Currently, the instructions for the challenge are after the cleanup. It results in some people cleaning up everything before even trying the challenge, as it is not announced. 
I suggest to put the challenge before the cleanup, or at least announce it