### PR TITLE
Fix cognito region of us-east-2

### DIFF
--- a/CloudFormation/CreateZombieWorkshop.json
+++ b/CloudFormation/CreateZombieWorkshop.json
@@ -27,7 +27,7 @@
       "us-east-2": {
         "S3Endpoint": "https://s3-us-east-2",
         "S3ContentsBucket": "aws-zombie-workshop-us-east-2",
-        "CognitoRegion": "us-east-1"
+        "CognitoRegion": "us-east-2"
       },
 
       "eu-west-1": {


### PR DESCRIPTION
Without this change the cloud formation template fails like this:

2016-12-15T04:53:04.884Z	5cf11886-c282-11e6-a637-ff415b7d855d	REQUEST RECEIVED:
{
    "RequestType": "Create",
    "ServiceToken": "arn:aws:lambda:us-east-2:673245392743:function:zombiestack-splunk-CognitoTriggerBuild-17JK744MQYU59",
    "ResponseURL": "https://cloudformation-custom-resource-response-useast2.s3.us-east-2.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-2%3A673245392743%3Astack/zombiestack-splunk/34dc7920-c282-11e6-acbf-50faf8bc7c9a%7CCreateCognitoTrigger%7C3a80bcdd-bc39-4100-a834-8dd5ae4b0f87?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20161215T045304Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7199&X-Amz-Credential=AKIAIGA4RXKH2NPMMYYA%2F20161215%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Signature=908d0015d5180d2b3407b3935801bbd60232f3504979469acbf1eca2cf0817c3",
    "StackId": "arn:aws:cloudformation:us-east-2:673245392743:stack/zombiestack-splunk/34dc7920-c282-11e6-acbf-50faf8bc7c9a",
    "RequestId": "3a80bcdd-bc39-4100-a834-8dd5ae4b0f87",
    "LogicalResourceId": "CreateCognitoTrigger",
    "ResourceType": "Custom::CreateCognitoTrigger",
    "ResourceProperties": {
        "ServiceToken": "arn:aws:lambda:us-east-2:673245392743:function:zombiestack-splunk-CognitoTriggerBuild-17JK744MQYU59",
        "IamRole": "arn:aws:iam::673245392743:role/zombiestack-splunk-ZombieLabLambdaRole-IHZLBVD2CQBJ",
        "CognitoRegion": "us-east-1",
        "LambdaFunctionBucket": "aws-zombie-workshop-us-east-2",
        "region": "us-east-2",
        "StackName": "zombiestack-splunk"
    }
}

2016-12-15T04:53:06.259Z	5cf11886-c282-11e6-a637-ff415b7d855d	Error creating cognitoLambdaTrigger function. Error is: InvalidParameterValueException: Error occurred while GetObject. S3 Error Code: AuthorizationHeaderMalformed. S3 Error Message: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-east-2'