### PR TITLE
Update write HTTP Request for ElasticSearch 6.x

### DIFF
--- a/ElasticSearchLambda/ZombieWorkshopSearchIndexing.js
+++ b/ElasticSearchLambda/ZombieWorkshopSearchIndexing.js
@@ -48,6 +48,7 @@ function postToES(doc, context) {
     req.region = esDomain.region;
     req.headers['presigned-expires'] = false;
     req.headers['Host'] = endpoint.host;
+    req.headers['Content-Type'] = "application/json";
     req.body = doc;
 
     console.log('Creating the Signer for the post request');


### PR DESCRIPTION
ElasticSearch 6.x has changed to enable strict content-type checking; need to set the header in the request