### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/CloudFormation/CreateZombieWorkshop.json
+++ b/CloudFormation/CreateZombieWorkshop.json
@@ -377,7 +377,7 @@
           "S3Bucket": { "Fn::FindInMap" : [ "AllowedRegions", { "Ref" : "AWS::Region" }, "S3ContentsBucket"]},
           "S3Key": "S3GetFilesFunction.zip"
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "120"
       },
       "DependsOn": [
@@ -395,7 +395,7 @@
           "S3Bucket": { "Ref" : "S3BucketForWebsiteContent" },
           "S3Key": "cognitoTriggerBuild.zip"
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "120"
       },
       "DependsOn": [
@@ -456,7 +456,7 @@
           "S3Bucket": { "Ref": "S3BucketForWebsiteContent" },
           "S3Key": "WK305_Gateway.zip"
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "300",
         "MemorySize": "1536"
       },
@@ -477,7 +477,7 @@
           "S3Bucket": { "Ref": "S3BucketForWebsiteContent" },
           "S3Key": "cognito.zip"
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "300",
         "MemorySize": "1536"
       },
@@ -520,7 +520,7 @@
           "S3Bucket": { "Ref" : "S3BucketForWebsiteContent" },
           "S3Key": "ZombiePostMessage.zip"
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "60"
       },
       "DependsOn": [
@@ -540,7 +540,7 @@
           "S3Bucket": { "Ref" : "S3BucketForWebsiteContent" },
           "S3Key": "ZombieGetMessages.zip"
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "60"
       },
       "DependsOn" : [
@@ -596,7 +596,7 @@
             "};\n"
             ]]}
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "10"
       },
       "DependsOn" : ["TalkersDynamoDBTable","ZombieLabLambdaRole"]
@@ -656,7 +656,7 @@
             "};\n"
             ]]}
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "10"
       },
       "DependsOn" : ["TalkersDynamoDBTable", "ZombieLabLambdaRole"]
@@ -686,7 +686,7 @@
           "S3Bucket": { "Ref" : "S3BucketForWebsiteContent" },
           "S3Key": "IamUsers.zip"
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "60"
       },
       "DependsOn": [


### PR DESCRIPTION
CloudFormation templates in aws-lambda-zombie-workshop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.